### PR TITLE
view-more 버튼 상태 렌더 처리 오류 해결

### DIFF
--- a/src/components/MovieListMore.ts
+++ b/src/components/MovieListMore.ts
@@ -6,16 +6,20 @@ export default class MovieListMore extends Component {
     super({
       tagName: 'button'
     });
-    movieStore.subscribe('pageMax', () => {
-      const { page, pageMax } = movieStore.state;
+    movieStore.subscribe('pageMax', () => this.updateVisibility());
+    this.updateVisibility();
+  }
+  updateVisibility() {
+    const { page, pageMax } = movieStore.state;
 
-      pageMax > page
-        ? this.el.classList.remove('hide')
-        : this.el.classList.add('hide');
-    });
+    if (pageMax > page) {
+      this.el.classList.remove('hide');
+    } else {
+      this.el.classList.add('hide');
+    }
   }
   render() {
-    this.el.classList.add('btn', 'view-more', 'hide');
+    this.el.classList.add('btn', 'view-more');
     this.el.textContent = 'More...';
 
     this.el.addEventListener('click', async () => {


### PR DESCRIPTION
### 문제점

1. Search 페이지에서 영화 검색 후 Movie 페이지 이동 → 다시 Search 페이지로 돌아오면 ‘View More’ 버튼이 사라짐
2. Search 페이지에서 영화 검색 → ‘View More’ 클릭해 목록 확장 → 영화 상세 클릭 → 뒤로 가기 시 버튼이 사라짐

### 원인

- 렌더링 시 `hide` 클래스를 단순히 부여하는 로직이 리렌더에 의해 덮어져 버튼이 사라지는 현상 발생

### 해결

- `subscribe()` 내부 처리 코드를 별도 함수로 분리
- 최초 렌더 시 조건문을 통해 `hide` 클래스를 적절히 부여하도록 개선